### PR TITLE
Default values should be returned

### DIFF
--- a/lib/class_kit/class_methods.rb
+++ b/lib/class_kit/class_methods.rb
@@ -13,13 +13,17 @@ module ClassKit
 
     class_eval do
       def self.new( *args, &blk)
-        o = allocate
+        o = super # get the result of an existing initializer
         attributes = o.class.instance_variable_get('@class_kit_attributes')
         return o unless attributes
 
+        # add any default attributes to instance variables unless they already have a value
         attributes.each_pair do |_, v|
+          current_value = o.public_send(v[:name])
           # TODO: Do we want to allow nils to be serialized?
-          o.instance_variable_set( "@#{v[:name]}", v[:default]) if v[:default]
+          unless current_value
+            o.instance_variable_set( "@#{v[:name]}", v[:default]) if v[:default]
+          end
         end
         o
       end
@@ -30,9 +34,7 @@ module ClassKit
         current_value = instance_variable_get(:"@#{name}")
 
         if current_value.nil?
-          if !cka[:default].nil?
-            current_value = instance_variable_set(:"@#{name}", cka[:default])
-          elsif cka[:auto_init]
+          if cka[:auto_init]
             current_value = instance_variable_set(:"@#{name}", cka[:type].new)
           end
         end

--- a/lib/class_kit/class_methods.rb
+++ b/lib/class_kit/class_methods.rb
@@ -12,8 +12,19 @@ module ClassKit
                          default: default, auto_init: auto_init, meta: meta }
 
     class_eval do
-      define_method name do
+      def self.new( *args, &blk)
+        o = allocate
+        attributes = o.class.instance_variable_get('@class_kit_attributes')
+        return o unless attributes
 
+        attributes.each_pair do |_, v|
+          # TODO: Do we want to allow nils to be serialized?
+          o.instance_variable_set( "@#{v[:name]}", v[:default]) if v[:default]
+        end
+        o
+      end
+
+      define_method name do
         cka = ClassKit::AttributeHelper.instance.get_attribute(klass: self.class, name: name)
 
         current_value = instance_variable_get(:"@#{name}")

--- a/spec/class_kit/class_methods_spec.rb
+++ b/spec/class_kit/class_methods_spec.rb
@@ -13,9 +13,17 @@ RSpec.describe ClassKit do
     TestEmptyChild.new
   end
 
-  it 'should have an instance variable for each default to allow .to_hash to work' do
-    t = TestWithDefaults.new
-    expect(t.instance_variables).to match_array([:@name, :@created_at])
+  context 'With an entity with defaults' do
+    subject { TestWithDefaults.new }
+
+    it 'should have an instance variable for each default to allow .to_hash to work' do
+      expect(subject.instance_variables).to match_array([:@age, :@name, :@created_at, :@variable_set_in_initializer])
+    end
+
+    it 'should still allow the class to set values in the initializer' do
+      expect(subject.name).to eq('New Name')
+      expect(subject.age).to eq(15)
+    end
   end
 
   context 'when setting the value of a base class attribute' do

--- a/spec/class_kit/class_methods_spec.rb
+++ b/spec/class_kit/class_methods_spec.rb
@@ -13,6 +13,11 @@ RSpec.describe ClassKit do
     TestEmptyChild.new
   end
 
+  it 'should have an instance variable for each default to allow .to_hash to work' do
+    t = TestWithDefaults.new
+    expect(t.instance_variables).to match_array([:@name, :@created_at])
+  end
+
   context 'when setting the value of a base class attribute' do
     it 'should not error' do
       child_entity.base1 = 'hello world'
@@ -308,5 +313,3 @@ RSpec.describe ClassKit do
 
   end
 end
-
-

--- a/spec/class_kit/helper_spec.rb
+++ b/spec/class_kit/helper_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe ClassKit::Helper do
         expect(hash[:postcode]).to eq(entity.postcode)
       end
     end
+
     context 'when an invalid class is specified' do
       let(:entity) do
         InvalidClass.new.tap do |e|
@@ -38,6 +39,28 @@ RSpec.describe ClassKit::Helper do
       end
       it 'should raise error' do
         expect{ subject.to_hash(entity) }.to raise_error(ClassKit::Exceptions::InvalidClassError)
+      end
+    end
+
+    context 'when defaults are used' do
+      let(:expected_attributes) { [:age, :name] }
+      let(:test_entity) do
+        t = TestWithDefaults.new
+        t.age = 18
+        t
+      end
+
+      context 'when we call the defaulted attributes first' do
+        it 'default values are returned' do
+          expect(test_entity.name).to eq('John Doe')
+          expect(subject.to_hash(test_entity).keys).to match_array(expected_attributes)
+        end
+      end
+
+      context 'when we dont call the defaulted attributes' do
+        it 'default values are returned' do
+          expect(subject.to_hash(test_entity).keys).to match_array(expected_attributes)
+        end
       end
     end
   end

--- a/spec/class_kit/helper_spec.rb
+++ b/spec/class_kit/helper_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+
 RSpec.describe ClassKit::Helper do
   describe '#validate_class_kit' do
     context 'when a class implements ClassKit is specified' do
@@ -43,16 +44,20 @@ RSpec.describe ClassKit::Helper do
     end
 
     context 'when defaults are used' do
-      let(:expected_attributes) { [:age, :name] }
+      let(:now) { Time.now }
       let(:test_entity) do
+        now
         t = TestWithDefaults.new
         t.age = 18
         t
       end
+      let(:expected_attributes) { [:age, :name, :created_at] }
 
       context 'when we call the defaulted attributes first' do
         it 'default values are returned' do
-          expect(test_entity.name).to eq('John Doe')
+          # call the default attributes
+          test_entity.name
+          test_entity.created_at
           expect(subject.to_hash(test_entity).keys).to match_array(expected_attributes)
         end
       end
@@ -60,6 +65,13 @@ RSpec.describe ClassKit::Helper do
       context 'when we dont call the defaulted attributes' do
         it 'default values are returned' do
           expect(subject.to_hash(test_entity).keys).to match_array(expected_attributes)
+        end
+      end
+
+      describe 'Default timestamps' do
+        it 'should generate the default timestamp when the class is instantiated and not when the method is called' do
+          sleep(2)
+          expect(subject.to_hash(test_entity)[:created_at].to_i).to be_within(now.to_i + 1).of(now.to_i)
         end
       end
     end

--- a/spec/class_kit/helper_spec.rb
+++ b/spec/class_kit/helper_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe ClassKit::Helper do
         t.age = 18
         t
       end
-      let(:expected_attributes) { [:age, :name, :created_at] }
+      let(:expected_attributes) { [:age, :name, :created_at, :variable_set_in_initializer] }
 
       context 'when we call the defaulted attributes first' do
         it 'default values are returned' do
@@ -188,7 +188,10 @@ RSpec.describe ClassKit::Helper do
     it 'should convert the class to json' do
       result = subject.to_json(entity)
       expect(result).to be_a(String)
-      expect(result).to eq(JSON.dump(hash))
+      # require 'pry'; binding.pry
+      # expect(result).to eq(JSON.dump(hash))
+      # require 'pry'; binding.pry
+      expect(JSON.parse(result)).to eq(JSON.parse(JSON.dump(hash)))
     end
   end
 

--- a/spec/class_kit/helper_spec.rb
+++ b/spec/class_kit/helper_spec.rb
@@ -185,12 +185,11 @@ RSpec.describe ClassKit::Helper do
                   ]
       }
     end
+
     it 'should convert the class to json' do
       result = subject.to_json(entity)
       expect(result).to be_a(String)
-      # require 'pry'; binding.pry
-      # expect(result).to eq(JSON.dump(hash))
-      # require 'pry'; binding.pry
+      # Parsing everything to json to make the test easier to read if it fails.
       expect(JSON.parse(result)).to eq(JSON.parse(JSON.dump(hash)))
     end
   end

--- a/spec/class_kit/test_objects.rb
+++ b/spec/class_kit/test_objects.rb
@@ -2,6 +2,7 @@ class TestWithDefaults
   extend ClassKit
   attr_accessor_type :name, default: 'John Doe'
   attr_accessor_type :age
+  attr_accessor_type :created_at, type: Time, default: Time.now
 end
 
 class TestAddress

--- a/spec/class_kit/test_objects.rb
+++ b/spec/class_kit/test_objects.rb
@@ -2,7 +2,14 @@ class TestWithDefaults
   extend ClassKit
   attr_accessor_type :name, default: 'John Doe'
   attr_accessor_type :age
+  attr_accessor_type :address
   attr_accessor_type :created_at, type: Time, default: Time.now
+
+  def initialize
+    @variable_set_in_initializer = 'done'
+    @name = 'New Name'
+    @age = 15
+  end
 end
 
 class TestAddress

--- a/spec/class_kit/test_objects.rb
+++ b/spec/class_kit/test_objects.rb
@@ -1,3 +1,9 @@
+class TestWithDefaults
+  extend ClassKit
+  attr_accessor_type :name, default: 'John Doe'
+  attr_accessor_type :age
+end
+
 class TestAddress
   extend ClassKit
   attr_accessor_type :line1, type: String


### PR DESCRIPTION
I believe that when converting an entity to hash the default values should be returned.

⚠️  There is a failing spec due to an empty collection that came through an initialized object.
Not sure if this is a problem or not.