### PR TITLE
serialisation updates

### DIFF
--- a/lib/class_kit/helper.rb
+++ b/lib/class_kit/helper.rb
@@ -20,7 +20,31 @@ module ClassKit
     def to_hash(object)
       validate_class_kit(object.class)
 
-      @hash_helper.to_hash(object)
+      hash = {}
+
+      attributes = @attribute_helper.get_attributes(object.class)
+      attributes.each do |attribute|
+        key = attribute[:name]
+        type = attribute[:type]
+        value = object.public_send(key)
+        if value != nil
+          hash[key] = if is_class_kit?(type)
+                        to_hash(value)
+                      elsif type == Array
+                        value.map do |i|
+                          if is_class_kit?(i.class)
+                            to_hash(i)
+                          else
+                            i
+                          end
+                        end
+                      else
+                        value
+                      end
+        end
+      end
+      @hash_helper.indifferent!(hash)
+      hash
     end
 
     #This method is called to convert a Hash into a ClassKit object.
@@ -63,7 +87,7 @@ module ClassKit
 
     #This method is called to convert a ClassKit object into JSON.
     def to_json(object)
-      hash = @hash_helper.to_hash(object)
+      hash = to_hash(object)
       JSON.dump(hash)
     end
 

--- a/script/test.sh
+++ b/script/test.sh
@@ -3,7 +3,4 @@
 echo start rspec tests
 docker-compose up -d
 
-
-spec_path=spec/$1
-
-docker exec -it gem_test_runner bash -c "cd gem_src && bundle install && bundle exec rspec ${spec_path}"
+docker exec -it gem_test_runner bash -c "cd gem_src && bundle install && bundle exec rspec $*"

--- a/spec/class_kit/attribute_helper_spec.rb
+++ b/spec/class_kit/attribute_helper_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe ClassKit::AttributeHelper do
     context 'when a class has NO polymorphism chain' do
       it 'should return all ClassKit attributes' do
         results = subject.get_attributes(TestAddress)
-        expect(results.length).to eq(3)
+        expect(results.length).to eq(4)
       end
     end
     context 'when a class DOES have a polymorphism chain' do

--- a/spec/class_kit/helper_spec.rb
+++ b/spec/class_kit/helper_spec.rb
@@ -28,6 +28,43 @@ RSpec.describe ClassKit::Helper do
         expect(hash[:line1]).to eq(entity.line1)
         expect(hash[:line2]).to eq(entity.line2)
         expect(hash[:postcode]).to eq(entity.postcode)
+        expect(hash[:country]).to eq(entity.country)
+      end
+    end
+    context 'when a valid class is specified with array attributes' do
+      let(:address1) do
+        TestAddress.new.tap do |e|
+          e.line1 = 'line1'
+          e.line2 = 'line2'
+          e.postcode = 'ne1 8rt'
+        end
+      end
+      let(:address2) do
+        TestAddress.new.tap do |e|
+          e.line1 = 'line1'
+          e.line2 = 'line2'
+          e.postcode = 'ne3 9rt'
+        end
+      end
+      let(:entity) do
+        TestEntity.new.tap do |e|
+          e.address_collection << address1
+          e.address_collection << address2
+        end
+      end
+      it 'should return a hash' do
+        hash = subject.to_hash(entity)
+        expect(hash).to be_a(Hash)
+        expect(hash[:address_collection]).to be_a(Array)
+        expect(hash[:address_collection].length).to eq 2
+
+        expect(hash[:address_collection][0][:line1]).to eq(address1.line1)
+        expect(hash[:address_collection][0][:line2]).to eq(address1.line2)
+        expect(hash[:address_collection][0][:postcode]).to eq(address1.postcode)
+
+        expect(hash[:address_collection][1][:line1]).to eq(address2.line1)
+        expect(hash[:address_collection][1][:line2]).to eq(address2.line2)
+        expect(hash[:address_collection][1][:postcode]).to eq(address2.postcode)
       end
     end
     context 'when an invalid class is specified' do
@@ -153,7 +190,10 @@ RSpec.describe ClassKit::Helper do
     it 'should convert the class to json' do
       result = subject.to_json(entity)
       expect(result).to be_a(String)
-      expect(result).to eq(JSON.dump(hash))
+      result_hash = JSON.load(result)
+      expect(result_hash['address']['post_code']).to eq(hash[:address][:post_code])
+      expect(result_hash['address_collection'].length).to eq(2)
+      expect(result_hash['address_collection'][0]['post_code']).to eq hash[:address_collection][0][:post_code]
     end
   end
 

--- a/spec/class_kit/test_objects.rb
+++ b/spec/class_kit/test_objects.rb
@@ -3,6 +3,7 @@ class TestAddress
   attr_accessor_type :line1, type: String
   attr_accessor_type :line2
   attr_accessor_type :postcode
+  attr_accessor_type :country, type: String, default: 'United Kingdom'
 end
 
 class TestEntity


### PR DESCRIPTION
updated helper to ensure `to_hash` and `to_json` methods only serialise class attributes not instance variables.