### PR TITLE
Declare dependency on bigdecimal

### DIFF
--- a/class_kit.gemspec
+++ b/class_kit.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'simplecov', ' ~> 0.22.0'
   spec.add_development_dependency 'simplecov_json_formatter'
 
+  spec.add_dependency 'bigdecimal'
   spec.add_dependency 'hash_kit'
   spec.add_dependency 'json'
 end

--- a/lib/class_kit/version.rb
+++ b/lib/class_kit/version.rb
@@ -1,5 +1,5 @@
 # Namespace
 module ClassKit
   # :nodoc:
-  VERSION = '0.9.0'
+  VERSION = '0.9.1'
 end


### PR DESCRIPTION
With Ruby 3.4.0 bigdecimal will no longer be part of the standard library and will need to be required as a gem. This change declares the dependency on bigdecimal in the gemspec.