### PR TITLE
Minor cleanup & release 0.10.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,16 +8,17 @@ jobs:
   publish:
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: write
+      id-token: write
+
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
+
+      - name: Configure trusted publishing credentials
+        uses: rubygems/configure-rubygems-credentials@v1.0.0
 
       - name: Publish to RubyGems
         run: |
-          mkdir -p $HOME/.gem
-          touch $HOME/.gem/credentials
-          chmod 0600 $HOME/.gem/credentials
-          printf -- "---\n:rubygems_api_key: ${GEM_HOST_API_KEY}\n" > $HOME/.gem/credentials
           gem build class_kit.gemspec
           gem push class_kit-*.gem
-        env:
-          GEM_HOST_API_KEY: "${{secrets.RUBYGEMS_AUTH_TOKEN}}"

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -6,10 +6,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.5
+          ruby-version: 4.0
           bundler-cache: true
 
       - name: Run tests

--- a/class_kit.gemspec
+++ b/class_kit.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'rubocop'
   spec.add_development_dependency 'simplecov', ' ~> 0.22.0'

--- a/lib/class_kit/attribute_helper.rb
+++ b/lib/class_kit/attribute_helper.rb
@@ -1,6 +1,5 @@
 module ClassKit
   class AttributeHelper
-
     def self.instance
       @instance ||= ClassKit::AttributeHelper.new
     end
@@ -18,12 +17,12 @@ module ClassKit
       return @attribute_store[klass] if @attribute_store.key?(klass)
 
       attributes = []
-      klass.ancestors.map do |k|
+      klass.ancestors.each do |k|
         hash = k.instance_variable_get(:@class_kit_attributes)
-        if hash != nil
-          hash.values.each do |a|
-            attributes.push(a)
-          end
+        next if hash.nil?
+
+        hash.each_value do |value|
+          attributes.push(value)
         end
       end
       attributes.compact!

--- a/lib/class_kit/version.rb
+++ b/lib/class_kit/version.rb
@@ -1,5 +1,5 @@
 # Namespace
 module ClassKit
   # :nodoc:
-  VERSION = '0.9.1'
+  VERSION = '0.10.0'
 end


### PR DESCRIPTION
- Replaces `#map` call with unused return value with `#each`
- Replaces `hash.values.each` with `hash.each_value`

Switch to trusted publisher and bump version to 0.10.0